### PR TITLE
Convert legacy command with curl to get_url command

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,4 @@
 ---
 warn_list:
   - role-name
-  - name
+  - name[casing]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,13 +22,9 @@
     - dropbox-download
 
 - name: download
-  ansible.builtin.command: >
-    curl -sSL
-    https://www.dropbox.com/download?dl=packages/{{ ansible_distribution | lower }}/dropbox_{{ dropbox_version }}_{{ dropbox_machine_map[ansible_machine] }}.deb
-    -o {{ dropbox_downloads_path }}/dropbox_{{ dropbox_version }}_{{ dropbox_machine_map[ansible_machine] }}.deb
-  args:
-    creates: "{{ dropbox_downloads_path }}/dropbox_{{ dropbox_version }}_{{ dropbox_machine_map[ansible_machine] }}.deb"
-    warn: false
+  ansible.builtin.get_url:
+    url: "https://www.dropbox.com/download?dl=packages/{{ ansible_distribution | lower }}/dropbox_{{ dropbox_version }}_{{ dropbox_machine_map[ansible_machine] }}.deb"
+    dest: "{{ dropbox_downloads_path }}/dropbox_{{ dropbox_version }}_{{ dropbox_machine_map[ansible_machine] }}.deb"
   tags:
     - configuration
     - dropbox


### PR DESCRIPTION
Apparently `ansible.builtin.command` doesn't allow the `creates` parameter anymore. But a curl command should be replaceable by `ansible.builtin.get_url`. 

It fixed my local issues and should also address the CI issues.